### PR TITLE
outputgen example: replace filesizes by filenames

### DIFF
--- a/outputgenerator/V6/example_nodejs/async.js
+++ b/outputgenerator/V6/example_nodejs/async.js
@@ -13,8 +13,8 @@ async function GeneratePDFFromWordTemplate(templateFile, dataFile) {
         const formData = new FormData();
         formData.append("resultType", "pdf");
         formData.append("async", 'true');
-        formData.append("data", fs.createReadStream(dataFileFilePath), { knownLength: fs.statSync(dataFileFilePath).size });
-        formData.append("wordTemplateData", fs.createReadStream(templateFilePath), { knownLength: fs.statSync(templateFilePath).size });
+        formData.append("data", fs.createReadStream(dataFileFilePath), dataFile);
+        formData.append("wordTemplateData", fs.createReadStream(templateFilePath), templateFile);
 
         // Add api key to headers
         const headers = {

--- a/outputgenerator/V6/example_nodejs/sync.js
+++ b/outputgenerator/V6/example_nodejs/sync.js
@@ -13,8 +13,8 @@ async function GeneratePDFFromWordTemplate(templateFile, dataFile) {
         const formData = new FormData();
         formData.append("resultType", "pdf");
         formData.append("async", 'false');
-        formData.append("data", fs.createReadStream(dataFileFilePath), { knownLength: fs.statSync(dataFileFilePath).size });
-        formData.append("wordTemplateData", fs.createReadStream(templateFilePath), { knownLength: fs.statSync(templateFilePath).size });
+        formData.append("data", fs.createReadStream(dataFileFilePath), dataFile);
+        formData.append("wordTemplateData", fs.createReadStream(templateFilePath), templateFile);
 
         // Add api key to headers
         const headers = {


### PR DESCRIPTION
Flexibere manier van oproepen omdat je de data filestream dan kan vervangen door JSON-stringified output van een API call